### PR TITLE
Core24, missing plug, build from tip of branch.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: iamb
-base: core22
+base: core24
 version: "v0.0.10"
 summary: A Matrix client for Vim addicts
 description: |
@@ -9,11 +9,11 @@ description: |
 grade: stable
 confinement: strict
 
-architectures:
-  - build-on: arm64
-  - build-on: amd64
-  - build-on: armhf
-  
+platforms:
+  amd64:
+  arm64:
+  armhf:
+
 parts:
   iamb:
     plugin: rust

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,3 +28,4 @@ apps:
     command: bin/iamb
     plugs:
       - network
+      - network-bind

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: iamb
 base: core24
-version: "v0.0.10"
+adopt-info: iamb
 summary: A Matrix client for Vim addicts
 description: |
   This project is a work-in-progress, and there's still a lot to be implemented,
@@ -17,7 +17,11 @@ platforms:
 parts:
   iamb:
     plugin: rust
-    source: https://github.com/ulyssa/iamb/archive/refs/tags/$SNAPCRAFT_PROJECT_VERSION.tar.gz
+    source: https://github.com/ulyssa/iamb
+    source-type: git
+    override-pull: |
+      craftctl default
+      craftctl set version="$(git describe --tags --abbrev=8)"
     
 apps:
   iamb:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,7 @@ platforms:
   amd64:
   arm64:
   armhf:
+  riscv64:
 
 parts:
   iamb:


### PR DESCRIPTION
Current Iamb snap cannot start with a generic "permission denied" error. This is due to Apparmor blockage of the listen syscall. The network-bind plug fixes it.

Once that is done, Iamb still failed to start with

> missing field `heroes` at line 1 column 223

Building from the tip of upstream's branch made the error go away and I can use Iamb now.